### PR TITLE
fix: start time could be equal to end time

### DIFF
--- a/Sources/SwiftSubtitles/coding/SRT.swift
+++ b/Sources/SwiftSubtitles/coding/SRT.swift
@@ -202,7 +202,7 @@ public extension Subtitles.Coder.SRT {
 					let s = Subtitles.Time(hour: s_hour, minute: s_min, second: s_sec, millisecond: s_ms)
 					let e = Subtitles.Time(hour: e_hour, minute: e_min, second: e_sec, millisecond: e_ms)
 
-					guard s < e else {
+					guard s <= e else {
 						throw SubTitlesError.startTimeAfterEndTime(item.offset)
 					}
 


### PR DESCRIPTION
I got some srt that sometimes start time is equal to end time, I think this should be ok?